### PR TITLE
Issue: #4 Updated stackexplain authentication through api_key and fixed import error

### DIFF
--- a/stackexplain/utilities/chatgpt.py
+++ b/stackexplain/utilities/chatgpt.py
@@ -3,7 +3,7 @@ import json
 import os.path as path
 
 # Third party
-from revChatGPT.revChatGPT import Chatbot
+from revChatGPT.V3 import Chatbot
 
 # Local
 from stackexplain.utilities.printers import prompt_user_for_credentials
@@ -40,8 +40,8 @@ def is_user_registered():
 
 
 def register_openai_credentials():
-    email, password = prompt_user_for_credentials()
-    config = {"email": email, "password": password}
+    api_key= prompt_user_for_credentials()
+    config = {"api_key": api_key}
 
     with open(CONFIG_FP, "w") as config_file:
         json.dump(config, config_file)
@@ -50,5 +50,5 @@ def register_openai_credentials():
 def get_chatgpt_explanation(language, error_message):
     config = json.load(open(CONFIG_FP))
     query = construct_query(language, error_message)
-    chatbot = Chatbot(config)
-    return chatbot.get_chat_response(query)["message"].strip()
+    chatbot = Chatbot(**config)
+    return chatbot.ask(query).strip()

--- a/stackexplain/utilities/chatgpt.py
+++ b/stackexplain/utilities/chatgpt.py
@@ -26,7 +26,6 @@ def construct_query(language, error_message):
     query += "\n```"
     query += f"\n{error_message}"
     query += "\n```"
-
     return query
 
 

--- a/stackexplain/utilities/printers.py
+++ b/stackexplain/utilities/printers.py
@@ -79,10 +79,9 @@ def print_invalid_language_message():
 
 def prompt_user_for_credentials():
     print(f"{BOLD}Please enter your OpenAI credentials.{END}\n")
-    email = input("Email address: ")
-    password = input("Password: ")
+    api_key = input("Api Key: ")
 
-    return email, password
+    return api_key 
 
 
 class LoadingMessage:


### PR DESCRIPTION
#4 This PR updates the stackexplain tool to use an openai apikey for authentication, replacing the previous authentication method which required a username and password. This simplifies the authentication process and makes it more secure.

In addition, this PR fixes an import error that occurred when running stackexplain for the first time. The error was caused by a missing module ('revChatGPT.revChatGPT') that was replaced with 'revChatGPT.V3' in "chatgpt.py" file.

The updated code has been tested and is working correctly. To test the changes, simply run pip install stackexplain and then run stackexplain error.py. The tool should now run without any import errors and use the new authentication method.