### PR TITLE
feat: added support for openai base url and model override

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Once installed, you can use OpenAI or Claude as your LLM provider. Just add the 
 > export ANTHROPIC_API_KEY="..."
 ```
 
+You can customize your OpenAI model and base url by adding the following to your environment:
+
+```bash
+> export OPENAI_MODEL="..." # default to "gpt-4o"
+> export OPENAI_BASE_URL="..." # default to None
+```
+
 You can also use a local model with Ollama. Just add the model name that's being served to your environment:
 
 ```bash

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if sys.version_info[:3] < (3, 0, 0):
 
 setup(
     name="wut-cli",
-    version="1.0.5",
+    version="1.0.6",
     description="CLI that explains the output of your last command",
     url="https://github.com/shobrook/wut",
     author="shobrook",

--- a/wut/utils.py
+++ b/wut/utils.py
@@ -239,13 +239,13 @@ def run_anthropic(system_message: str, user_message: str) -> str:
 
 
 def run_openai(system_message: str, user_message: str) -> str:
-    openai = OpenAI()
+    openai = OpenAI(base_url=os.getenv("OPENAI_BASE_URL", None))
     response = openai.chat.completions.create(
         messages=[
             {"role": "system", "content": system_message},
             {"role": "user", "content": user_message},
         ],
-        model="gpt-4o",
+        model=os.getenv("OPENAI_MODEL", None) or "gpt-4o",
         temperature=0.7,
     )
     return response.choices[0].message.content


### PR DESCRIPTION
Hi. This PR introduces features related to OpenAI integration. First, it allows users to specify a custom base URL using the `OPENAI_BASE_URL` environment variable. If not set, the default OpenAI API endpoint is used. This is useful for users who need to use a different endpoint, such as a proxy or a specialized OpenAI deployment. Second, it allows users to specify which OpenAI model to use via the `OPENAI_MODEL` environment variable. If not set, it defaults to `gpt-4o`.