### PR TITLE
Add support for Zellij

### DIFF
--- a/wut/wut.py
+++ b/wut/wut.py
@@ -41,9 +41,9 @@ def main():
 
     with console.status("[bold green]Trying my best..."):
         # Ensure environment is set up correctly
-        if not os.environ.get("TMUX") and not os.environ.get("STY"):
+        if not os.environ.get("TMUX") and not os.environ.get("STY") and not os.environ.get("ZELLIJ"):
             console.print(
-                "[bold red]wut must be run inside a tmux or screen session.[/bold red]"
+                "[bold red]wut must be run inside a tmux, screen, or Zellij session.[/bold red]"
             )
             return
         if (


### PR DESCRIPTION
Related to #11

Update the environment check in `wut/wut.py` to support Zellij.

* Modify the check to include `os.environ.get("ZELLIJ")`.
* Update the error message to include Zellij, indicating that `wut` must be run inside a tmux, screen, or Zellij session.

