### PR TITLE
Add support for llm-manager / Ollama

### DIFF
--- a/wut/utils.py
+++ b/wut/utils.py
@@ -274,6 +274,22 @@ def get_llm_provider() -> str:
     if os.getenv("OLLAMA_MODEL", None):
         return "ollama"
 
+    xdg_config_home = os.getenv("XDG_CONFIG_HOME", expanduser("~/.config"))
+    config_paths = [
+        join(xdg_config_home, "llm-manager", "llm.conf"),
+        "/etc/llm.conf"
+    ]
+    for config_file in config_paths:
+        if exists(config_file):
+            with open(config_file, "r") as f:
+                lines = f.readlines()
+            for line in lines:
+                if "=" in line:
+                    key, value = line.split("=", 1)
+                    if key.strip() == "code":
+                        os.environ["OLLAMA_MODEL"] = value.strip()
+                        return "ollama"
+
     raise ValueError("No API key found for OpenAI or Anthropic.")
 
 


### PR DESCRIPTION
Hi!

This is a feature request.

[`llm-manager`](https://github.com/xyproto/llm-manager) is available on Arch Linux, and makes it easy to choose a user-defined Ollama model, per task.

This PR is just a suggestion for code that could be added to `wut`. Another options is to run `llm-manager code` to get the name of the Ollama model intended for analyzing and creating code, as specified with the user (CPU, GPU and memory may vary a lot from system to system).

Thanks for creating `wut`!